### PR TITLE
Conditionally run `npm install` in tmp directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules/
 /lib/
+.DS_Store

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,15 +9,20 @@ import archiver from "archiver";
 import cryptoRandomString from "crypto-random-string";
 import commander from "commander";
 
+export interface CaxaOptions {
+	directory: string;
+	command: string[];
+	output: string;
+ 	filter?:(src:string, dest:string)=>boolean
+  }
+
+
 export default async function caxa({
   directory,
   command,
   output,
-}: {
-  directory: string;
-  command: string[];
-  output: string;
-}): Promise<void> {
+  filter,
+}:CaxaOptions ): Promise<void> {
   if (
     !(await fs.pathExists(directory)) ||
     !(await fs.lstat(directory)).isDirectory()
@@ -29,7 +34,7 @@ export default async function caxa({
     cryptoRandomString({ length: 10, type: "alphanumeric" }).toLowerCase()
   );
   const appDirectory = path.join(os.tmpdir(), "caxa", identifier);
-  await fs.copy(directory, appDirectory);
+  await fs.copy(directory, appDirectory, {filter});
 
   // if we did not copy a node modules folder, but there is a package or package-lock file, run npm install
   if (!(await fs.pathExists(path.join(appDirectory, "node_modules")))) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,17 +32,25 @@ export default async function caxa({
   await fs.copy(directory, appDirectory);
 
   // if we did not copy a node modules folder, but there is a package or package-lock file, run npm install
-  if(!(await fs.pathExists(path.join(appDirectory, 'node_modules')))){
-      const packageLockPath = path.join(appDirectory, 'package-lock.json')
-      const packageJsonPath = path.join(appDirectory, 'package.json')
-      // prefer using package-lock, if available
-      if(await fs.pathExists(packageLockPath)){
-        console.log(`Installing deps from package-lock.json`)
-        await execa('npm', ['ci', '--prod'], { cwd: appDirectory })
-      } else if (await fs.pathExists(packageJsonPath)){
-        console.log(`Installing deps from package.json`)
-        await execa('npm', ['i', '--prod'], { cwd: appDirectory })
+  if (!(await fs.pathExists(path.join(appDirectory, "node_modules")))) {
+    const packageLockPath = path.join(appDirectory, "package-lock.json");
+    const packageJsonPath = path.join(appDirectory, "package.json");
+    // prefer using package-lock, if available
+    try {
+      if (await fs.pathExists(packageLockPath)) {
+        await execa("npm", ["ci"], { cwd: appDirectory }).catch();
+      } else if (await fs.pathExists(packageJsonPath)) {
+        throw null;
       }
+    } catch (err) {
+      try {
+        console.log(`install from package.json`, appDirectory);
+        await execa("npm", ["i"], { cwd: appDirectory });
+      } catch (e) {
+        // pass, nothing we can do here
+        console.log(e);
+      }
+    }
   }
   await execa("npm", ["prune", "--production"], { cwd: appDirectory });
   await execa("npm", ["dedupe"], { cwd: appDirectory });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "include": ["src/**/*.ts"],
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "lib",


### PR DESCRIPTION
First off, let me say thank you for this elegant and clever solution! Having used both pkg and nexe for years, I always thought it could be as simple as this, so kudos for just getting it done. By the look of the README, you've clearly done your homework on this, and I'm excited to offer a bit of my own suggestion with this PR.

## Why
I'm currently battling an issue with pkg involving some native dependencies, etc. (super common story, I'm sure). This code is part of a medium-sized Nx monorepo, which keeps things organized, but has the downside of having one large `node_modules` folder for multiple apps. Using their new build tool, it's possible to generate a `package.json` file as a build artifact which includes only the required dependencies for the particular app or library; while this is great, I don't love the idea of having to run `npm install` on a folder in our build artifacts tree before I bundle it with `caxa`. 

## Solution
Just before running `npm prune` check for the existence of a `node_modules` folder in the temp directory, and if one is **not** found, then check for either a `package.json` or `package-lock.json`, running `npm ci ` for package-lock, and standard `npm i` for package. `npm ci` is the preferred option, as it creates a (more) deterministic environment.

Cheers, and thanks again for a great solution to this problem!