### PR TITLE
Add CAXA_APP and CAXA_HOME envs

### DIFF
--- a/stubs/stub.go
+++ b/stubs/stub.go
@@ -75,6 +75,9 @@ func main() {
 	}
 
 	command := exec.Command(expandedCommand[0], append(expandedCommand[1:], os.Args[1:]...)...)
+	command.Env = os.Environ()
+	command.Env = append(command.Env, "CAXA_APP=" + footer.Identifier)
+	command.Env = append(command.Env, "CAXA_HOME=" + appDirectory)
 	command.Stdin = os.Stdin
 	command.Stdout = os.Stdout
 	command.Stderr = os.Stderr


### PR DESCRIPTION
First of all thank you very much for this enlighten and simple app wrapper. Just awesome!

I would like to identify a running caxa environment and the current path of the app for further file interaction. This PR adds basic caxa environment variables to identify caxa app and its home directory. With this PR it is possible to check and switch business logic if the app runs as caxa app.

CAXA_APP is set to the caxa identifier and CAXA_HOME to the extracted archive location.