### PR TITLE
Add optional initial message

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ export default async function caxa({
     cryptoRandomString({ length: 10, type: "alphanumeric" }).toLowerCase()
   ),
   removeBuildDirectory = true,
+  initialMessage
 }: {
   input: string;
   output: string;
@@ -53,6 +54,7 @@ export default async function caxa({
   stub?: string;
   identifier?: string;
   removeBuildDirectory?: boolean;
+  initialMessage?: string;
 }): Promise<void> {
   if (!(await fs.pathExists(input)) || !(await fs.lstat(input)).isDirectory())
     throw new Error(
@@ -132,7 +134,9 @@ export default async function caxa({
       archiveStream.on("finish", resolve);
       archiveStream.on("error", reject);
     });
-    await fs.appendFile(output, "\n" + JSON.stringify({ identifier, command }));
+
+    const footer = { identifier, command, initialMessage }
+    await fs.appendFile(output, "\n" + JSON.stringify(footer));
   }
 
   if (removeBuildDirectory) await fs.remove(buildDirectory);
@@ -180,6 +184,10 @@ if (require.main === module)
         true
       )
       .option("-B, --no-remove-build-directory")
+      .option(
+        "-m, --initial-message <message>",
+        "Allows an optional message to be displayed on initial run as this can take some time."
+      )
       .arguments("<command...>")
       .description("Package Node.js applications into executable binaries.", {
         command:
@@ -214,6 +222,7 @@ Examples:
             stub,
             identifier,
             removeBuildDirectory,
+            initialMessage
           }: {
             input: string;
             output: string;
@@ -225,6 +234,7 @@ Examples:
             stub?: string;
             identifier?: string;
             removeBuildDirectory?: boolean;
+            initialMessage?: string;
           }
         ) => {
           try {
@@ -240,6 +250,7 @@ Examples:
               stub,
               identifier,
               removeBuildDirectory,
+              initialMessage
             });
           } catch (error) {
             console.error(error.message);


### PR DESCRIPTION
Hi, I recently discovered this project and happy to say it significantly simplified our internal build process so many thanks for creating this!

I actually received similar feedback in my project relevant to https://github.com/leafac/caxa/issues/23 so I wanted to push up a solution i've been working on. Hopefully this helps, if there is any feedback you have that can help adoption on your side, let me know!


Thanks again for the project!

Notes on usage: This introduces a new "-m, --initial-message" argument to caxa which will be provided to the stub via footer at runtime. Also, this wasn't necessarily part of the initial request but I did include a progress indicator similar unit-test dot reporters. Every 5 seconds a dot will be printed so the user knows the application is still unpacking and has not hung-up. On windows boxes the slow IO during unpacking can convince users that the application is hung and they may initiate a force quit. This in turn causes us to be a really bad state because subsequent runs will not trigger re-unpacking of a partially unarchived application but instead will run from a directory with only a portion of the artifacts present.

Examples:

Using optional parameter
`$ caxa --input "dist" --output "builds/example-macos" --initial-message "First run detected, unpacking may take some time" "{{caxa}}/node_modules/.bin/node" "{{caxa}}/index.js"`

Output on first start 
```
$./example-macos
First run detected, unpacking may take some time
..
Unpacking complete.
Program started.
```

Without optional parameter
`$ caxa --input "dist" --output "builds/example-macos" "{{caxa}}/node_modules/.bin/node" "{{caxa}}/index.js"`

Output on first start 
```
$./example-macos
Program started.
```