### PR TITLE
fix: use user cache directory instead of tmp

### DIFF
--- a/source/index.mts
+++ b/source/index.mts
@@ -134,13 +134,16 @@ export default async function caxa({
     let stub =
       bash`
         #!/usr/bin/env sh
-        export CAXA_TEMPORARY_DIRECTORY="$(dirname $(mktemp))/caxa"
+        export CAXA_DIRECTORY="${process.platform === "darwin"
+          ? bash`$HOME/Library/Caches`
+          : bash("${XDG_CACHE_HOME-$HOME/.cache}")
+        }/caxa"
         export CAXA_EXTRACTION_ATTEMPT=-1
         while true
         do
           export CAXA_EXTRACTION_ATTEMPT=$(( CAXA_EXTRACTION_ATTEMPT + 1 ))
-          export CAXA_LOCK="$CAXA_TEMPORARY_DIRECTORY/locks/${identifier}/$CAXA_EXTRACTION_ATTEMPT"
-          export CAXA_APPLICATION_DIRECTORY="$CAXA_TEMPORARY_DIRECTORY/applications/${identifier}/$CAXA_EXTRACTION_ATTEMPT"
+          export CAXA_LOCK="$CAXA_DIRECTORY/locks/${identifier}/$CAXA_EXTRACTION_ATTEMPT"
+          export CAXA_APPLICATION_DIRECTORY="$CAXA_DIRECTORY/applications/${identifier}/$CAXA_EXTRACTION_ATTEMPT"
           if [ -d "$CAXA_APPLICATION_DIRECTORY" ] 
           then
             if [ -d "$CAXA_LOCK" ] 
@@ -150,11 +153,10 @@ export default async function caxa({
               break
             fi
           else
-            ${
-              uncompressionMessage === undefined
-                ? bash``
-                : bash`echo "${uncompressionMessage}" >&2`
-            }
+            ${uncompressionMessage === undefined
+          ? bash``
+          : bash`echo "${uncompressionMessage}" >&2`
+        }
             mkdir -p "$CAXA_LOCK"
             mkdir -p "$CAXA_APPLICATION_DIRECTORY"
             tail -n+{{caxa-number-of-lines}} "$0" | tar -xz -C "$CAXA_APPLICATION_DIRECTORY"
@@ -215,8 +217,7 @@ if (process.env.TEST === "caxa") {
   await (async () => {
     const output = path.join(
       testsDirectory,
-      `echo-command-line-parameters${
-        process.platform === "win32" ? ".exe" : ""
+      `echo-command-line-parameters${process.platform === "win32" ? ".exe" : ""
       }`
     );
     await execa(process.execPath, [
@@ -375,8 +376,7 @@ if (process.env.TEST === "caxa") {
   await (async () => {
     const output = path.join(
       testsDirectory,
-      `echo-command-line-parameters--no-force${
-        process.platform === "win32" ? ".exe" : ""
+      `echo-command-line-parameters--no-force${process.platform === "win32" ? ".exe" : ""
       }`
     );
     await fs.ensureDir(path.dirname(output));
@@ -438,8 +438,7 @@ if (process.env.TEST === "caxa") {
   await (async () => {
     const output = path.join(
       testsDirectory,
-      `echo-command-line-parameters--exclude${
-        process.platform === "win32" ? ".exe" : ""
+      `echo-command-line-parameters--exclude${process.platform === "win32" ? ".exe" : ""
       }`
     );
     await execa(process.execPath, [
@@ -463,8 +462,7 @@ if (process.env.TEST === "caxa") {
   await (async () => {
     const output = path.join(
       testsDirectory,
-      `echo-command-line-parameters--no-dedupe${
-        process.platform === "win32" ? ".exe" : ""
+      `echo-command-line-parameters--no-dedupe${process.platform === "win32" ? ".exe" : ""
       }`
     );
     await execa(process.execPath, [
@@ -487,8 +485,7 @@ if (process.env.TEST === "caxa") {
   await (async () => {
     const output = path.join(
       testsDirectory,
-      `echo-command-line-parameters--prepare-command${
-        process.platform === "win32" ? ".exe" : ""
+      `echo-command-line-parameters--prepare-command${process.platform === "win32" ? ".exe" : ""
       }`
     );
     await execa(process.execPath, [
@@ -512,8 +509,7 @@ if (process.env.TEST === "caxa") {
   await (async () => {
     const output = path.join(
       testsDirectory,
-      `echo-command-line-parameters--no-include-node${
-        process.platform === "win32" ? ".exe" : ""
+      `echo-command-line-parameters--no-include-node${process.platform === "win32" ? ".exe" : ""
       }`
     );
     await execa(process.execPath, [
@@ -536,8 +532,7 @@ if (process.env.TEST === "caxa") {
   await (async () => {
     const output = path.join(
       testsDirectory,
-      `echo-command-line-parameters--stub${
-        process.platform === "win32" ? ".exe" : ""
+      `echo-command-line-parameters--stub${process.platform === "win32" ? ".exe" : ""
       }`
     );
     assert.equal(
@@ -569,8 +564,7 @@ if (process.env.TEST === "caxa") {
   await (async () => {
     const output = path.join(
       testsDirectory,
-      `echo-command-line-parameters--identifier${
-        process.platform === "win32" ? ".exe" : ""
+      `echo-command-line-parameters--identifier${process.platform === "win32" ? ".exe" : ""
       }`
     );
     await execa(process.execPath, [
@@ -594,8 +588,7 @@ if (process.env.TEST === "caxa") {
   await (async () => {
     const output = path.join(
       testsDirectory,
-      `echo-command-line-parameters--no-remove-build-directory${
-        process.platform === "win32" ? ".exe" : ""
+      `echo-command-line-parameters--no-remove-build-directory${process.platform === "win32" ? ".exe" : ""
       }`
     );
     await execa(process.execPath, [
@@ -620,8 +613,7 @@ if (process.env.TEST === "caxa") {
   await (async () => {
     const output = path.join(
       testsDirectory,
-      `echo-command-line-parameters--uncompression-message${
-        process.platform === "win32" ? ".exe" : ""
+      `echo-command-line-parameters--uncompression-message${process.platform === "win32" ? ".exe" : ""
       }`
     );
     await execa(process.execPath, [
@@ -709,7 +701,7 @@ if (url.fileURLToPath(import.meta.url) === (await fs.realpath(process.argv[1])))
     .addHelpText(
       "after",
       "\n" +
-        dedent`
+      dedent`
           Examples:
             Windows:
             > caxa --input "examples/echo-command-line-parameters" --output "echo-command-line-parameters.exe" -- "{{caxa}}/node_modules/.bin/node" "{{caxa}}/index.mjs" "some" "embedded arguments" "--an-option-thats-part-of-the-command"

--- a/source/index.mts
+++ b/source/index.mts
@@ -134,9 +134,10 @@ export default async function caxa({
     let stub =
       bash`
         #!/usr/bin/env sh
-        export CAXA_DIRECTORY="${process.platform === "darwin"
-          ? bash`$HOME/Library/Caches`
-          : bash("${XDG_CACHE_HOME-$HOME/.cache}")
+        export CAXA_DIRECTORY="${
+          process.platform === "darwin"
+            ? bash`$HOME/Library/Caches`
+            : bash("${XDG_CACHE_HOME-$HOME/.cache}")
         }/caxa"
         export CAXA_EXTRACTION_ATTEMPT=-1
         while true
@@ -153,10 +154,11 @@ export default async function caxa({
               break
             fi
           else
-            ${uncompressionMessage === undefined
-          ? bash``
-          : bash`echo "${uncompressionMessage}" >&2`
-        }
+            ${
+              uncompressionMessage === undefined
+                ? bash``
+                : bash`echo "${uncompressionMessage}" >&2`
+            }
             mkdir -p "$CAXA_LOCK"
             mkdir -p "$CAXA_APPLICATION_DIRECTORY"
             tail -n+{{caxa-number-of-lines}} "$0" | tar -xz -C "$CAXA_APPLICATION_DIRECTORY"
@@ -217,7 +219,8 @@ if (process.env.TEST === "caxa") {
   await (async () => {
     const output = path.join(
       testsDirectory,
-      `echo-command-line-parameters${process.platform === "win32" ? ".exe" : ""
+      `echo-command-line-parameters${
+        process.platform === "win32" ? ".exe" : ""
       }`
     );
     await execa(process.execPath, [
@@ -376,7 +379,8 @@ if (process.env.TEST === "caxa") {
   await (async () => {
     const output = path.join(
       testsDirectory,
-      `echo-command-line-parameters--no-force${process.platform === "win32" ? ".exe" : ""
+      `echo-command-line-parameters--no-force${
+        process.platform === "win32" ? ".exe" : ""
       }`
     );
     await fs.ensureDir(path.dirname(output));
@@ -438,7 +442,8 @@ if (process.env.TEST === "caxa") {
   await (async () => {
     const output = path.join(
       testsDirectory,
-      `echo-command-line-parameters--exclude${process.platform === "win32" ? ".exe" : ""
+      `echo-command-line-parameters--exclude${
+        process.platform === "win32" ? ".exe" : ""
       }`
     );
     await execa(process.execPath, [
@@ -462,7 +467,8 @@ if (process.env.TEST === "caxa") {
   await (async () => {
     const output = path.join(
       testsDirectory,
-      `echo-command-line-parameters--no-dedupe${process.platform === "win32" ? ".exe" : ""
+      `echo-command-line-parameters--no-dedupe${
+        process.platform === "win32" ? ".exe" : ""
       }`
     );
     await execa(process.execPath, [
@@ -485,7 +491,8 @@ if (process.env.TEST === "caxa") {
   await (async () => {
     const output = path.join(
       testsDirectory,
-      `echo-command-line-parameters--prepare-command${process.platform === "win32" ? ".exe" : ""
+      `echo-command-line-parameters--prepare-command${
+        process.platform === "win32" ? ".exe" : ""
       }`
     );
     await execa(process.execPath, [
@@ -509,7 +516,8 @@ if (process.env.TEST === "caxa") {
   await (async () => {
     const output = path.join(
       testsDirectory,
-      `echo-command-line-parameters--no-include-node${process.platform === "win32" ? ".exe" : ""
+      `echo-command-line-parameters--no-include-node${
+        process.platform === "win32" ? ".exe" : ""
       }`
     );
     await execa(process.execPath, [
@@ -532,7 +540,8 @@ if (process.env.TEST === "caxa") {
   await (async () => {
     const output = path.join(
       testsDirectory,
-      `echo-command-line-parameters--stub${process.platform === "win32" ? ".exe" : ""
+      `echo-command-line-parameters--stub${
+        process.platform === "win32" ? ".exe" : ""
       }`
     );
     assert.equal(
@@ -564,7 +573,8 @@ if (process.env.TEST === "caxa") {
   await (async () => {
     const output = path.join(
       testsDirectory,
-      `echo-command-line-parameters--identifier${process.platform === "win32" ? ".exe" : ""
+      `echo-command-line-parameters--identifier${
+        process.platform === "win32" ? ".exe" : ""
       }`
     );
     await execa(process.execPath, [
@@ -588,7 +598,8 @@ if (process.env.TEST === "caxa") {
   await (async () => {
     const output = path.join(
       testsDirectory,
-      `echo-command-line-parameters--no-remove-build-directory${process.platform === "win32" ? ".exe" : ""
+      `echo-command-line-parameters--no-remove-build-directory${
+        process.platform === "win32" ? ".exe" : ""
       }`
     );
     await execa(process.execPath, [
@@ -613,7 +624,8 @@ if (process.env.TEST === "caxa") {
   await (async () => {
     const output = path.join(
       testsDirectory,
-      `echo-command-line-parameters--uncompression-message${process.platform === "win32" ? ".exe" : ""
+      `echo-command-line-parameters--uncompression-message${
+        process.platform === "win32" ? ".exe" : ""
       }`
     );
     await execa(process.execPath, [
@@ -701,7 +713,7 @@ if (url.fileURLToPath(import.meta.url) === (await fs.realpath(process.argv[1])))
     .addHelpText(
       "after",
       "\n" +
-      dedent`
+        dedent`
           Examples:
             Windows:
             > caxa --input "examples/echo-command-line-parameters" --output "echo-command-line-parameters.exe" -- "{{caxa}}/node_modules/.bin/node" "{{caxa}}/index.mjs" "some" "embedded arguments" "--an-option-thats-part-of-the-command"

--- a/stubs/stub.go
+++ b/stubs/stub.go
@@ -46,10 +46,15 @@ func main() {
 		log.Fatalf("caxa stub: Failed to parse JSON in footer: %v", err)
 	}
 
+	cacheDirectory, err := os.UserCacheDir()
+	if err != nil {
+		log.Fatalf("caxa stub: Failed to get the user cache directory: %v", err)
+	}
+	caxaDirectory := path.Join(cacheDirectory, "caxa")
 	var applicationDirectory string
 	for extractionAttempt := 0; true; extractionAttempt++ {
-		lock := path.Join(os.TempDir(), "caxa/locks", footer.Identifier, strconv.Itoa(extractionAttempt))
-		applicationDirectory = path.Join(os.TempDir(), "caxa/applications", footer.Identifier, strconv.Itoa(extractionAttempt))
+		lock := path.Join(caxaDirectory, "locks", footer.Identifier, strconv.Itoa(extractionAttempt))
+		applicationDirectory = path.Join(caxaDirectory, "applications", footer.Identifier, strconv.Itoa(extractionAttempt))
 		applicationDirectoryFileInfo, err := os.Stat(applicationDirectory)
 		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			log.Fatalf("caxa stub: Failed to find information about the application directory: %v", err)


### PR DESCRIPTION
This changes the extraction directory to the user cache using [`os.UserCacheDir()`](https://pkg.go.dev/os#UserCacheDir).

Fixes #37. Related to #20.